### PR TITLE
Creates a changelog file and updates release notes

### DIFF
--- a/lib/release_notes.rb
+++ b/lib/release_notes.rb
@@ -2,4 +2,6 @@ module ReleaseNotes
   require 'release_notes/github_api'
   require 'release_notes/manager'
   require 'release_notes/changelog_parser'
+  require 'release_notes/changelog_file'
+  require 'release_notes/github_release'
 end

--- a/lib/release_notes/changelog_file.rb
+++ b/lib/release_notes/changelog_file.rb
@@ -1,0 +1,50 @@
+module ReleaseNotes
+  class ChangelogFile
+
+    attr_accessor :server_name, :file_path
+
+    def initialize(server_name, file_path)
+      @server_name = server_name
+      @file_path = file_path
+      @file = File.open(file_path, 'a+') # need to create it if it doesn't already exist
+    end
+
+    def metadata
+      find_last_metadata
+    end
+
+    def update_changelog(changelog_text, verification_text)
+      original_file = "./#{file_path}"
+      new_file = original_file + '.new'
+
+      open(new_file, 'w') do |f|
+       f.puts [changelog_header,changelog_text].join("\n\n") + "\n\n"
+       f.puts verification_text.to_json
+       f.puts "\n\n"
+       File.foreach(original_file) do |li|
+         f.puts li
+       end
+      end
+
+      File.rename(original_file, original_file + '.old')
+      File.rename(new_file, original_file)
+    end
+
+    def release_verification_text(new_sha, old_sha, new_tag_sha: nil)
+      {"#{server_name}": {old_sha: old_sha, new_tag_sha: new_tag_sha, commit_sha: new_sha}}
+    end
+
+    private
+
+    def find_last_metadata
+      File.open(file_path, "r") do |f|
+        text = f.read
+        text[/{"#{server_name}"(.*)/]
+      end
+    end
+
+    def changelog_header
+      "## Deployed to: #{server_name} (#{Time.now.utc.asctime})"
+    end
+  end
+end

--- a/lib/release_notes/changelog_parser.rb
+++ b/lib/release_notes/changelog_parser.rb
@@ -9,6 +9,12 @@ module ReleaseNotes
       changelog_text(change_texts)
     end
 
+    def self.last_commit(server_name, metadata)
+      return nil unless metadata
+      metadata = JSON.parse(metadata)
+      metadata[server_name]["commit_sha"]
+    end
+
     private
 
     def self.changelog_text(texts)

--- a/lib/release_notes/github_api.rb
+++ b/lib/release_notes/github_api.rb
@@ -46,6 +46,10 @@ module ReleaseNotes
       @client.pull_request_commits(@repo, pr)
     end
 
+    def branch(branch)
+      @client.branch(@repo, branch)
+    end
+
     def releases
       populate_releases_metadata(@client.releases(@repo))
     end

--- a/lib/release_notes/github_release.rb
+++ b/lib/release_notes/github_release.rb
@@ -1,0 +1,45 @@
+module ReleaseNotes
+  class GithubRelease
+
+    attr_accessor :server_name
+
+    def initialize(server_name, api)
+      @server_name = server_name
+      @api = api
+    end
+
+    def update_release_notes(new_tag, old_sha, text: nil, verification_text: nil)
+      release = find_current_release(new_tag.tag)
+
+      if release.metadata[server_name]
+        puts "Release Notes are already updated for Server #{server_name}"
+        return release
+      end
+
+      @api.update_release(release, [release_notes_headers(server_name, old_sha), text].join("\n\n"), verification_text)
+    end
+
+    private
+
+    # find which release this server was last deployed to
+    def find_latest_release(server_name: nil)
+      return releases.find { |r| r.metadata.keys.include?(server_name.to_s) } if server_name
+    end
+
+    def find_current_release(tag_name)
+      @api.find_release(tag_name)
+    rescue Octokit::NotFound
+      @api.create_release(tag_name)
+      @api.find_release(tag_name)
+    end
+
+    def releases
+      @api.releases
+    end
+
+    def release_notes_headers(server_name, old_sha)
+      changes = "Changes Since: Tag " if old_sha
+      ["## Deployed to: #{server_name} (#{Time.now.utc.asctime})", "### " + changes.to_s + old_sha]
+    end
+  end
+end

--- a/lib/release_notes/manager.rb
+++ b/lib/release_notes/manager.rb
@@ -53,7 +53,7 @@ module ReleaseNotes
       end
     end
 
-    def find_latest_published_tag(old_release) # will be used to find latest release later
+    def find_latest_published_tag(old_release)
       @api.find_tag_by_name(old_release.tag_name)
     end
   end


### PR DESCRIPTION
- creates a file with changelog per server_name.
- makes it easier to see all the changes for each server
- still updates the release notes if a tag_name is passed
- allows users to just pass branch_name instead of tag_name if no tag was created.

Still need to refactor the way metadata is read from github. Should be moved into github_releases not from the github_api.