### PR TITLE
Optomize Merged PRs List

### DIFF
--- a/lib/release_notes/manager.rb
+++ b/lib/release_notes/manager.rb
@@ -42,12 +42,12 @@ module ReleaseNotes
 
     def texts_from_merged_pr(new_sha, old_sha)
       commits_between_tags = @api.find_commits_between(old_sha, new_sha)
-      matching_pr_commits(commits_between_tags).map { |commit| {number: commit.number, title: commit.title, text: commit.body.squish } }
+      matching_pr_commits(commits_between_tags, old_sha).map { |commit| {number: commit.number, title: commit.title, text: commit.body.squish } }
     end
 
     # find the prs that contain the commits between two tags
-    def matching_pr_commits(commits)
-      @api.merged_pull_requests.select do |pr|
+    def matching_pr_commits(commits, old_sha)
+      @api.merged_pull_requests(old_sha).select do |pr|
         (@api.find_pull_request_commits(pr.number).map(&:sha) - commits.map(&:sha)).empty?
       end
     end

--- a/spec/lib/release_notes/manager_spec.rb
+++ b/spec/lib/release_notes/manager_spec.rb
@@ -19,6 +19,10 @@ describe ReleaseNotes::Manager do
     let(:branch) { create_branch }
     let(:pr) { setup_issue_commit_pr('master', branch) }
 
+    before(:each) do
+      sleep 1 # Github Best Practices https://developer.github.com/guides/best-practices-for-integrators/#dealing-with-rate-limits
+    end
+
     before(:each) { branch; pr }
 
     subject { ReleaseNotes::Manager.new(@repo, @access_token, DEFAULT_SERVER) }


### PR DESCRIPTION
Optomize Merged PRs List
- fixes problem with looking through each pr to see if it has been merged
- only takes prs from before a specific date (the last_commits commit date)