### PR TITLE
Adds summary to commit message

### DIFF
--- a/lib/release_notes/changelog_file.rb
+++ b/lib/release_notes/changelog_file.rb
@@ -27,11 +27,12 @@ module ReleaseNotes
       File.rename(new_file, original_file)
     end
 
-    def push_changelog_to_github
+    def push_changelog_to_github(prs)
       changelog_content = File.read(@file_path)
       file = @api.find_content(@file_path)
       if file.present?
-        @api.update_changelog(file, changelog_content)
+        summary = changelog_header + "\n\n" + ChangelogParser.changelog_summary(prs).join("\n\n")
+        @api.update_changelog(file, summary, changelog_content)
       else
         @api.create_content(@file_path, changelog_content)
       end

--- a/lib/release_notes/changelog_parser.rb
+++ b/lib/release_notes/changelog_parser.rb
@@ -24,6 +24,12 @@ module ReleaseNotes
       end
     end
 
+    def self.changelog_summary(prs)
+      prs.map do |pr|
+        [header_text(pr[:number], pr[:title]), "Closes:", section_text(pr[:text], "# Closes")].join(' ')
+      end
+    end
+
     def self.header_text(number, title)
       [ "###### ##{number}", title ].join(' - ')
     end

--- a/lib/release_notes/github_api.rb
+++ b/lib/release_notes/github_api.rb
@@ -62,8 +62,8 @@ module ReleaseNotes
       return nil
     end
 
-    def update_changelog(file, changelog_content, message: "Updating Changelog", branch: "master")
-      @client.update_contents(@repo, file.path, message, file.sha, changelog_content, branch: "master")
+    def update_changelog(file, summary, changelog_content, branch: "master")
+      @client.update_contents(@repo, file.path, summary, file.sha, changelog_content, branch: "master")
     end
 
     def create_content(changelog_file, changelog_content, message: "Updating Changelog", branch: "master")

--- a/lib/release_notes/manager.rb
+++ b/lib/release_notes/manager.rb
@@ -24,10 +24,11 @@ module ReleaseNotes
 
     def create_changelog_from_sha(new_sha)
       old_sha = ChangelogParser.last_commit(server_name, @changelog.metadata)
-      text = changelog_body(new_sha, old_sha)
+      prs = texts_from_merged_pr(new_sha, old_sha)
+      text = changelog_body(old_sha, prs)
 
       @changelog.update_changelog(text, new_sha, old_sha)
-      @changelog.push_changelog_to_github
+      @changelog.push_changelog_to_github(prs)
     end
 
     private
@@ -36,8 +37,8 @@ module ReleaseNotes
       @api.branch(branch).commit.sha
     end
 
-    def changelog_body(new_sha, old_sha)
-      old_sha.present? ? ChangelogParser.assemble_changelog(texts_from_merged_pr(new_sha, old_sha)) : "First Deploy"
+    def changelog_body(old_sha, prs)
+      old_sha.present? ? ChangelogParser.assemble_changelog(prs) : "First Deploy"
     end
 
     def texts_from_merged_pr(new_sha, old_sha)


### PR DESCRIPTION
Creates a summary for the commit message
- the prs #, and title that were closed, and the issues closed by that pr.
- this is because the markdown file pushed to github is not clickable, but the commit message is (making it easier for jay and nicole to navigate to).