### PR TITLE
Fix issue when nothing to compare against.

### DIFF
--- a/lib/release_notes/github_api.rb
+++ b/lib/release_notes/github_api.rb
@@ -66,7 +66,7 @@ module ReleaseNotes
       @client.update_contents(@repo, file.path, summary, file.sha, changelog_content, branch: "master")
     end
 
-    def create_content(changelog_file, changelog_content, message: "Updating Changelog", branch: "master")
+    def create_content(changelog_file, changelog_content, message: "Creating Changelog", branch: "master")
       @client.create_content(@repo, changelog_file, message, branch: branch, file: changelog_file)
     end
   end

--- a/lib/release_notes/manager.rb
+++ b/lib/release_notes/manager.rb
@@ -24,7 +24,8 @@ module ReleaseNotes
 
     def create_changelog_from_sha(new_sha)
       old_sha = ChangelogParser.last_commit(server_name, @changelog.metadata)
-      prs = texts_from_merged_pr(new_sha, old_sha)
+
+      prs = texts_from_merged_pr(new_sha, old_sha) if old_sha
       text = changelog_body(old_sha, prs)
 
       @changelog.update_changelog(text, new_sha, old_sha)


### PR DESCRIPTION
Can’t run texts from merged prs if there is no old sha to compare against. Refactored this recently and left out this check to make sure that we don’t get it if there is no old sha.