### PR TITLE
Allow old sha

### DIFF
--- a/lib/release_notes/changelog_file.rb
+++ b/lib/release_notes/changelog_file.rb
@@ -19,7 +19,7 @@ module ReleaseNotes
       new_file = original_file + '.new'
 
       open(new_file, 'w') do |f|
-        f.puts [changelog_header,changelog_text].join("\n\n") + "\n\n" + release_verification_text(new_sha, old_sha).to_json + "\n\n"
+        f.puts [changelog_header,changelog_text].join("\n\n") + "\n\n" + "[meta_data]: " + release_verification_text(new_sha, old_sha).to_json + "\n\n"
         f.puts File.read(original_file)
       end
 


### PR DESCRIPTION
- hides the metadata. 
- if old sha is available users can pass it in
- allows users to pass in type of changelog they want to create (git_changelog, local_changelog, release_notes).
- based on the type of changelog the user wants we can create different behaviour.
- right now this only allows for :git_changelog but hopefully this can diversify in the future.

TODO: Need to update metadata to also take in type and decide how to find the old_sha.