### PR TITLE
Removes Files after pushed to github

### DIFF
--- a/lib/release_notes/changelog_file.rb
+++ b/lib/release_notes/changelog_file.rb
@@ -38,6 +38,11 @@ module ReleaseNotes
       end
     end
 
+    def remove_files
+      File.delete(@file_path)
+      File.delete("#{@file_path}.old")
+    end
+
     def release_verification_text(new_sha, old_sha)
       {"#{server_name}": {old_sha: old_sha, commit_sha: new_sha}}
     end

--- a/lib/release_notes/changelog_parser.rb
+++ b/lib/release_notes/changelog_parser.rb
@@ -27,6 +27,7 @@ module ReleaseNotes
     private
 
     def self.changelog_prs(prs)
+      return [] unless prs
       prs.select { |pr| pr if pr[:text].include?(INCLUDE_PR_TEXT) }
     end
 

--- a/lib/release_notes/manager.rb
+++ b/lib/release_notes/manager.rb
@@ -30,12 +30,7 @@ module ReleaseNotes
 
       @changelog.update_changelog(text, new_sha, old_sha)
       @changelog.push_changelog_to_github(prs)
-    end
-
-    private
-
-    def branch_sha(branch)
-      @api.branch(branch).commit.sha
+      @changelog.remove_files
     end
 
     def changelog_body(old_sha, prs)
@@ -45,6 +40,12 @@ module ReleaseNotes
     def texts_from_merged_pr(new_sha, old_sha)
       commits_between_tags = @api.find_commits_between(old_sha, new_sha)
       matching_pr_commits(commits_between_tags, old_sha).map { |commit| {number: commit.number, title: commit.title, text: commit.body.squish } }
+    end
+
+    private
+
+    def branch_sha(branch)
+      @api.branch(branch).commit.sha
     end
 
     # find the prs that contain the commits between two tags

--- a/spec/lib/release_notes/changelog_file_spec.rb
+++ b/spec/lib/release_notes/changelog_file_spec.rb
@@ -1,0 +1,19 @@
+require 'release_notes'
+
+describe ReleaseNotes::ChangelogFile do
+
+  describe "#remove_files" do
+    subject { ReleaseNotes::ChangelogFile.new('prod', "prod_changelog.md", "api") }
+
+    before(:each) { subject.update_changelog("First Deploy", "new_sha", "old_sha") }
+
+    it "should have the files created on update_changelog" do
+      expect(File.exist?("prod_changelog.md")).to be true
+    end
+
+    it "should remove the files created on update changelog" do
+      subject.remove_files
+      expect(File.exist?("prod_changelog.md")).to be false
+    end
+  end
+end


### PR DESCRIPTION
- after the changelog has been pushed to github, delete both the files( changelog.md and changelog.md.old). We can pull back down the changelog.md when needed.

TODO: Update the changelog to read from github rather than from local file.