### PR TITLE
Old sha pass in

### DIFF
--- a/lib/release_notes/changelog_parser.rb
+++ b/lib/release_notes/changelog_parser.rb
@@ -10,11 +10,21 @@ module ReleaseNotes
       ["#### Closed PRS:", changelog_prs_text(changelog_prs)].join("\n\n")
     end
 
+    def self.update_changelog(changelog_text, new_sha, old_sha, server_name)
+      [changelog_header(server_name), changelog_text].join("\n\n") + "\n\n" + "[meta_data]: " + release_verification_text(new_sha, old_sha, server_name).to_json + "\n\n"
+    end
+
     def self.last_commit(server_name, metadata)
       return nil unless metadata
       metadata = JSON.parse(metadata)
       metadata[server_name]["commit_sha"]
     end
+
+    def self.create_summary(prs, server_name)
+      [changelog_header(server_name), changelog_summary(prs).join("\n\n")].join("\n\n")
+    end
+
+    private
 
     def self.changelog_summary(prs)
       changelog_prs = changelog_prs(prs)
@@ -23,8 +33,6 @@ module ReleaseNotes
         ["Closed PR: ##{pr[:number]} - #{pr[:title]}", "Closes:", section_text(pr[:text], "# Closes")].join(' ')
       end
     end
-
-    private
 
     def self.changelog_prs(prs)
       return [] unless prs
@@ -35,6 +43,14 @@ module ReleaseNotes
       prs.map do |pr|
         [header_text(pr[:number], pr[:title]), changelog_text(pr[:text])].join("\n\n")
       end
+    end
+
+    def self.changelog_header(server_name)
+      "## Deployed to: #{server_name} (#{Time.now.utc.asctime})"
+    end
+
+    def self.release_verification_text(new_sha, old_sha, server_name)
+      {"#{server_name}": {old_sha: old_sha, commit_sha: new_sha}}
     end
 
     def self.header_text(number, title)

--- a/lib/release_notes/manager.rb
+++ b/lib/release_notes/manager.rb
@@ -12,25 +12,23 @@ module ReleaseNotes
       @changelog = ChangelogFile.new(server_name, changelog_file, @api)
     end
 
-    def create_changelog_from_branch(branch)
+    def create_changelog_from_branch(branch, old_sha: nil)
       new_sha = branch_sha(branch)
-      create_changelog_from_sha(new_sha)
+      create_changelog_from_sha(new_sha, old_sha)
     end
 
-    def create_changelog_from_tag(tag_name)
+    def create_changelog_from_tag(tag_name, old_sha: nil)
       new_tag = @api.find_tag_by_name(tag_name)
-      create_changelog_from_sha(new_tag.object.sha)
+      create_changelog_from_sha(new_tag.object.sha, old_sha)
     end
 
-    def create_changelog_from_sha(new_sha)
-      old_sha = ChangelogParser.last_commit(server_name, @changelog.metadata)
+    def create_changelog_from_sha(new_sha, old_sha)
+      old_sha ||= ChangelogParser.last_commit(server_name, @changelog.metadata)
 
       prs = texts_from_merged_pr(new_sha, old_sha) if old_sha
       text = changelog_body(old_sha, prs)
 
-      @changelog.update_changelog(text, new_sha, old_sha)
-      @changelog.push_changelog_to_github(prs)
-      @changelog.remove_files
+      @changelog.update(text, new_sha, old_sha, prs)
     end
 
     def changelog_body(old_sha, prs)

--- a/spec/lib/release_notes/changelog_file_spec.rb
+++ b/spec/lib/release_notes/changelog_file_spec.rb
@@ -5,7 +5,10 @@ describe ReleaseNotes::ChangelogFile do
   describe "#remove_files" do
     subject { ReleaseNotes::ChangelogFile.new('prod', "prod_changelog.md", "api") }
 
-    before(:each) { subject.update_changelog("First Deploy", "new_sha", "old_sha") }
+    before(:each) do
+      allow(subject).to receive(:github_file).and_return(nil)
+      subject.update_changelog("First Deploy")
+    end
 
     it "should have the files created on update_changelog" do
       expect(File.exist?("prod_changelog.md")).to be true


### PR DESCRIPTION
- allows users to pass in old_sha
- creates the content from the changelog on github rather than the local file.
- refactors the generic information to the changelog_parser and keeps the specific code for github_changelog in the changelog_file.
- updates specs

Closes #6 