### PR TITLE
Set changelog repo path

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,14 +47,14 @@ changelog = release_manager.create_changelog_from_sha('sha')
 ```
 
 2. Push the changelog to Github:
-Once the changelog has been created, you can push it to Github. By default, the changelog will be saved to the repo initialized in the ReleaseNotes Manager. If you would like the release notes to appear in other repos, pass in the name of those repos.
+Once the changelog has been created, you can push it to Github. By default, the changelog will be saved to the repo initialized in the ReleaseNotes Manager. To save the changelog on other repos, pass the name of **all** the repos you would like the changelog to appear in, including the initialized repo.
 
 ``` ruby
 # Default
 release_manager.push_changelog_to_github(changelog)
 
 # Pass in repo names where you want the changelog to be created
-release_manager.push_changelog_to_github(changelog, 'github_user/another_repo', 'github_user/extra_repo')
+release_manager.push_changelog_to_github(changelog, 'github_user/your_repo', 'github_user/another_repo')
 
 ```
 

--- a/README.md
+++ b/README.md
@@ -30,18 +30,35 @@ gem 'release_notes', :github => 'clouie87/release_notes'
 2. Create an [OAuth token](https://developer.github.com/v3/oauth/) to access your repo through the Github API. You can [create access tokens in GitHub Account Settings](https://help.github.com/articles/creating-an-access-token-for-command-line-use/).
 
 ### Usage
+1. Create a changelog:
 Pass the ReleaseNotes Manager your repo, the access_token and server name. There are methods that can be called to create the changelog:
+
 ```ruby
-release_manager = ReleaseNotes::Manager.new('your repo', 'access token', 'server_name')
+release_manager = ReleaseNotes::Manager.new('github_user/your_repo', 'access token', 'server_name')
 
 # create changelog by branch
-release_manager.create_changelog_from_branch('branch_name')
+changelog = release_manager.create_changelog_from_branch('branch_name')
 
 # create changelog by tag
-release_manager.create_changelog_from_tag('tag_name')
+changelog = release_manager.create_changelog_from_tag('tag_name')
 
 # create changelog by sha
-release_manager.create_changelog_from_sha('sha')
+changelog = release_manager.create_changelog_from_sha('sha')
+```
+
+2. Push the changelog to Github:
+Once the changelog has been created, you can push it to Github. By default, the changelog will be saved to the repo initialized in the ReleaseNotes Manager. If you would like the release notes to appear in other repos, pass in the name of those repos.
+
+``` ruby
+# Default
+release_manager.push_changelog_to_github(changelog)
+
+# Pass in repo names where you want the changelog to be created
+release_manager.push_changelog_to_github(changelog, 'github_user/another_repo', 'github_user/extra_repo')
+
 ```
 
 Then on Github, a file will be added to your project `{server_name}_changelog.md`
+
+### Future Plans:
+- allow the changelog to be emailed or printed.

--- a/lib/release_notes/changelog_file.rb
+++ b/lib/release_notes/changelog_file.rb
@@ -6,7 +6,7 @@ module ReleaseNotes
     attr_accessor :server_name, :file_path
 
     def initialize(server_name, api)
-      @file_path = "#{server_name.downcase.parameterize.snakecase}_changelog.md"
+      @file_path = "#{server_name.downcase.parameterize.underscore}_changelog.md"
       @server_name = server_name
       @api = api
     end
@@ -16,12 +16,12 @@ module ReleaseNotes
         body: ChangelogParser.prepare_changelog_body(new_sha, old_sha, server_name, prs) }
     end
 
-    def push_to_github(changelog)
+    def push_to_github(repo, changelog)
       if github_file.present?
         changelog_body = changelog[:body] + old_changelog_content
-        @api.update_changelog(github_file, changelog[:summary], changelog_body)
+        @api.update_changelog(repo, github_file, changelog[:summary], changelog_body)
       else
-        @api.create_content(@file_path, changelog)
+        @api.create_content(repo, @file_path, changelog[:body])
       end
     end
 

--- a/lib/release_notes/changelog_file.rb
+++ b/lib/release_notes/changelog_file.rb
@@ -11,9 +11,9 @@ module ReleaseNotes
       @api = api
     end
 
-    def prepare(text, new_sha, old_sha, prs)
-      { summary: ChangelogParser.create_summary(prs, server_name),
-        body: ChangelogParser.update_changelog(text, new_sha, old_sha, server_name) }
+    def prepare(new_sha, old_sha, prs)
+      { summary: ChangelogParser.prepare_changelog_summary(server_name, prs),
+        body: ChangelogParser.prepare_changelog_body(new_sha, old_sha, server_name, prs) }
     end
 
     def push_to_github(changelog)

--- a/lib/release_notes/changelog_file.rb
+++ b/lib/release_notes/changelog_file.rb
@@ -5,11 +5,10 @@ module ReleaseNotes
 
     attr_accessor :server_name, :file_path
 
-    def initialize(server_name, api, changelog_repo)
+    def initialize(server_name, api)
       @file_path = "#{server_name.downcase.parameterize.snakecase}_changelog.md"
       @server_name = server_name
       @api = api
-      @changelog_repo = changelog_repo
     end
 
     def update(text, new_sha, old_sha, prs)
@@ -25,9 +24,9 @@ module ReleaseNotes
     def push_changelog_to_github(changelog_content, summary)
       if github_file.present?
         content = changelog_content + old_changelog_content
-        @api.update_changelog(github_file, summary, content, changelog_repo: @changelog_repo)
+        @api.update_changelog(github_file, content, summary)
       else
-        @api.create_content(@file_path, changelog_content, changelog_repo: @changelog_repo)
+        @api.create_content(@file_path, changelog_content)
       end
     end
 

--- a/lib/release_notes/changelog_file.rb
+++ b/lib/release_notes/changelog_file.rb
@@ -5,10 +5,11 @@ module ReleaseNotes
 
     attr_accessor :server_name, :file_path
 
-    def initialize(server_name, api)
+    def initialize(server_name, api, changelog_repo)
       @file_path = "#{server_name.downcase.parameterize.snakecase}_changelog.md"
       @server_name = server_name
       @api = api
+      @changelog_repo = changelog_repo
     end
 
     def update(text, new_sha, old_sha, prs)
@@ -24,9 +25,9 @@ module ReleaseNotes
     def push_changelog_to_github(changelog_content, summary)
       if github_file.present?
         content = changelog_content + old_changelog_content
-        @api.update_changelog(github_file, summary, content)
+        @api.update_changelog(github_file, summary, content, changelog_repo: @changelog_repo)
       else
-        @api.create_content(@file_path, changelog_content)
+        @api.create_content(@file_path, changelog_content, changelog_repo: @changelog_repo)
       end
     end
 

--- a/lib/release_notes/changelog_file.rb
+++ b/lib/release_notes/changelog_file.rb
@@ -6,7 +6,7 @@ module ReleaseNotes
     attr_accessor :server_name, :file_path
 
     def initialize(server_name, api)
-      @file_path = "#{server_name}_changelog.md"
+      @file_path = "#{server_name.downcase.parameterize.snakecase}_changelog.md"
       @server_name = server_name
       @api = api
     end

--- a/lib/release_notes/changelog_file.rb
+++ b/lib/release_notes/changelog_file.rb
@@ -11,23 +11,22 @@ module ReleaseNotes
       @api = api
     end
 
-    def update(text, new_sha, old_sha, prs)
-      summary = ChangelogParser.create_summary(prs, server_name)
-      changelog_content = ChangelogParser.update_changelog(text, new_sha, old_sha, server_name)
-      push_changelog_to_github(changelog_content, summary)
+    def prepare(text, new_sha, old_sha, prs)
+      { summary: ChangelogParser.create_summary(prs, server_name),
+        body: ChangelogParser.update_changelog(text, new_sha, old_sha, server_name) }
+    end
+
+    def push_to_github(changelog)
+      if github_file.present?
+        changelog_body = changelog[:body] + old_changelog_content
+        @api.update_changelog(github_file, changelog[:summary], changelog_body)
+      else
+        @api.create_content(@file_path, changelog)
+      end
     end
 
     def metadata
       find_last_metadata
-    end
-
-    def push_changelog_to_github(changelog_content, summary)
-      if github_file.present?
-        content = changelog_content + old_changelog_content
-        @api.update_changelog(github_file, content, summary)
-      else
-        @api.create_content(@file_path, changelog_content)
-      end
     end
 
     private

--- a/lib/release_notes/changelog_file.rb
+++ b/lib/release_notes/changelog_file.rb
@@ -35,14 +35,14 @@ module ReleaseNotes
       @api.find_content(@file_path)
     end
 
-    def old_changelog_content
-      return nil unless github_file.present?
-      Base64.decode64(github_file.content).force_encoding("UTF-8")
-    end
-
     def find_last_metadata
       return nil unless old_changelog_content.present?
       old_changelog_content[/{"#{server_name}"(.*)/]
+    end
+
+    def old_changelog_content
+      return nil unless github_file.present?
+      Base64.decode64(github_file.content).force_encoding("UTF-8")
     end
   end
 end

--- a/lib/release_notes/changelog_parser.rb
+++ b/lib/release_notes/changelog_parser.rb
@@ -11,7 +11,8 @@ module ReleaseNotes
     end
 
     def self.update_changelog(changelog_text, new_sha, old_sha, server_name)
-      ["## #{changelog_header(server_name)}", changelog_text].join("\n\n") + "\n\n" + "[meta_data]: " + release_verification_text(new_sha, old_sha, server_name).to_json + "\n\n"
+      metadata_content = "<!-- [meta_data]: #{release_verification_text(new_sha, old_sha, server_name).to_json} -->\n\n"
+      ["## #{changelog_header(server_name)}", changelog_text, metadata_content].join("\n\n")
     end
 
     def self.last_commit(server_name, metadata)

--- a/lib/release_notes/changelog_parser.rb
+++ b/lib/release_notes/changelog_parser.rb
@@ -4,15 +4,16 @@ module ReleaseNotes
     INCLUDE_PR_TEXT = "[x] Include this PR in the changelog".freeze
     END_STRING = /#\W\S/
 
-    def self.assemble_changelog(prs)
-      changelog_prs = changelog_prs(prs)
-      return "No Closed PRS" if changelog_prs.empty?
-      ["#### Closed PRS:", changelog_prs_text(changelog_prs)].join("\n\n")
+    def self.prepare_changelog_body(new_sha, old_sha, server_name, prs)
+      header_text = "## #{changelog_header(server_name)}"
+      changelog_body = body_text(old_sha, prs)
+      metadata_content = "<!-- [meta_data]: #{release_verification_text(new_sha, old_sha, server_name).to_json} -->\n\n"
+
+      [header_text, changelog_body, metadata_content].join("\n\n")
     end
 
-    def self.update_changelog(changelog_text, new_sha, old_sha, server_name)
-      metadata_content = "<!-- [meta_data]: #{release_verification_text(new_sha, old_sha, server_name).to_json} -->\n\n"
-      ["## #{changelog_header(server_name)}", changelog_text, metadata_content].join("\n\n")
+    def self.prepare_changelog_summary(server_name, prs)
+      [changelog_header(server_name), changelog_summary(prs).join("\n\n")].join("\n\n")
     end
 
     def self.last_commit(server_name, metadata)
@@ -21,11 +22,15 @@ module ReleaseNotes
       metadata[server_name]["commit_sha"]
     end
 
-    def self.create_summary(prs, server_name)
-      [changelog_header(server_name), changelog_summary(prs).join("\n\n")].join("\n\n")
-    end
-
     private
+
+    def self.body_text(old_sha, prs)
+      return "First Deploy" unless old_sha.present?
+
+      changelog_prs = changelog_prs(prs)
+      return "No Closed PRS" if changelog_prs.empty?
+      ["#### Closed PRS:", changelog_prs_text(changelog_prs)].join("\n\n")
+    end
 
     def self.changelog_summary(prs)
       changelog_prs = changelog_prs(prs)

--- a/lib/release_notes/changelog_parser.rb
+++ b/lib/release_notes/changelog_parser.rb
@@ -7,7 +7,7 @@ module ReleaseNotes
     def self.prepare_changelog_body(new_sha, old_sha, server_name, prs)
       header_text = "## #{changelog_header(server_name)}"
       changelog_body = body_text(old_sha, prs)
-      metadata_content = "<!-- [meta_data]: #{release_verification_text(new_sha, old_sha, server_name).to_json} -->\n\n"
+      metadata_content = "[meta_data]: #{release_verification_text(new_sha, old_sha, server_name).to_json}\n\n"
 
       [header_text, changelog_body, metadata_content].join("\n\n")
     end

--- a/lib/release_notes/changelog_parser.rb
+++ b/lib/release_notes/changelog_parser.rb
@@ -46,7 +46,7 @@ module ReleaseNotes
     end
 
     def self.changelog_header(server_name)
-      "Deployed to: #{server_name} (#{Time.now.utc.asctime})"
+      "Deployed to: #{server_name} (#{Time.now.strftime("%a %b %e %Y at %T")})"
     end
 
     def self.release_verification_text(new_sha, old_sha, server_name)

--- a/lib/release_notes/github_api.rb
+++ b/lib/release_notes/github_api.rb
@@ -62,11 +62,13 @@ module ReleaseNotes
       return nil
     end
 
-    def update_changelog(file, summary, changelog_content, branch: "master")
+    def update_changelog(file, summary, changelog_content, changelog_repo: nil, branch: "master")
+      @client.update_contents(changelog_repo, file.path, summary, file.sha, changelog_content, branch: "master") if changelog_repo
       @client.update_contents(@repo, file.path, summary, file.sha, changelog_content, branch: "master")
     end
 
-    def create_content(file, changelog_content, message: "Creating Changelog", branch: "master")
+    def create_content(file, changelog_content, message: "Creating Changelog", changelog_repo: nil, branch: "master")
+      @client.create_content(changelog_repo, file, message, changelog_content, branch: branch) if changelog_repo
       @client.create_content(@repo, file, message, changelog_content, branch: branch)
     end
   end

--- a/lib/release_notes/github_api.rb
+++ b/lib/release_notes/github_api.rb
@@ -62,13 +62,11 @@ module ReleaseNotes
       return nil
     end
 
-    def update_changelog(file, summary, changelog_content, changelog_repo: nil, branch: "master")
-      @client.update_contents(changelog_repo, file.path, summary, file.sha, changelog_content, branch: "master") if changelog_repo
+    def update_changelog(file, summary, changelog_content, branch: "master")
       @client.update_contents(@repo, file.path, summary, file.sha, changelog_content, branch: "master")
     end
 
-    def create_content(file, changelog_content, message: "Creating Changelog", changelog_repo: nil, branch: "master")
-      @client.create_content(changelog_repo, file, message, changelog_content, branch: branch) if changelog_repo
+    def create_content(file, changelog_content, message: "Creating Changelog", branch: "master")
       @client.create_content(@repo, file, message, changelog_content, branch: branch)
     end
   end

--- a/lib/release_notes/github_api.rb
+++ b/lib/release_notes/github_api.rb
@@ -62,12 +62,12 @@ module ReleaseNotes
       return nil
     end
 
-    def update_changelog(file, summary, changelog_content, branch: "master")
-      @client.update_contents(@repo, file.path, summary, file.sha, changelog_content, branch: "master")
+    def update_changelog(repo, file, summary, changelog_content, branch: "master")
+      @client.update_contents(repo, file.path, summary, file.sha, changelog_content, branch: "master")
     end
 
-    def create_content(file, changelog_content, message: "Creating Changelog", branch: "master")
-      @client.create_content(@repo, file, message, changelog_content, branch: branch)
+    def create_content(repo, file, changelog_content, message: "Creating Changelog", branch: "master")
+      @client.create_content(repo, file, message, changelog_content, branch: branch)
     end
   end
 end

--- a/lib/release_notes/manager.rb
+++ b/lib/release_notes/manager.rb
@@ -5,10 +5,10 @@ module ReleaseNotes
 
     attr_accessor :server_name
 
-    def initialize(repo, token, server_name)
+    def initialize(repo, token, server_name, changelog_repo: nil)
       @api = GithubAPI.new(repo, token)
       @server_name = server_name
-      @changelog = ChangelogFile.new(server_name, @api)
+      @changelog = ChangelogFile.new(server_name, @api, changelog_repo)
     end
 
     def create_changelog_from_branch(branch, old_sha: nil)

--- a/lib/release_notes/manager.rb
+++ b/lib/release_notes/manager.rb
@@ -31,7 +31,7 @@ module ReleaseNotes
 
     def push_changelog_to_github(content, *repos)
       repos = Array(@repo) if repos.empty?
-      repos.each do |repo|
+      repos.flatten.each do |repo|
         @changelog.push_to_github(repo, content)
       end
     end

--- a/lib/release_notes/manager.rb
+++ b/lib/release_notes/manager.rb
@@ -25,9 +25,8 @@ module ReleaseNotes
       old_sha ||= last_commit_sha
 
       prs = texts_from_merged_pr(new_sha, old_sha) if old_sha
-      text = changelog_body(old_sha, prs)
 
-      @changelog.prepare(text, new_sha, old_sha, prs)
+      @changelog.prepare(new_sha, old_sha, prs)
     end
 
     def push_changelog_to_github(content)
@@ -42,10 +41,6 @@ module ReleaseNotes
 
     def last_commit_sha
       ChangelogParser.last_commit(server_name, @changelog.metadata)
-    end
-
-    def changelog_body(old_sha, prs)
-      old_sha.present? ? ChangelogParser.assemble_changelog(prs) : "First Deploy"
     end
 
     def texts_from_merged_pr(new_sha, old_sha)

--- a/lib/release_notes/manager.rb
+++ b/lib/release_notes/manager.rb
@@ -5,10 +5,10 @@ module ReleaseNotes
 
     attr_accessor :server_name
 
-    def initialize(repo, token, server_name, changelog_repo: nil)
+    def initialize(repo, token, server_name)
       @api = GithubAPI.new(repo, token)
       @server_name = server_name
-      @changelog = ChangelogFile.new(server_name, @api, changelog_repo)
+      @changelog = ChangelogFile.new(server_name, @api)
     end
 
     def create_changelog_from_branch(branch, old_sha: nil)

--- a/lib/release_notes/version.rb
+++ b/lib/release_notes/version.rb
@@ -1,3 +1,3 @@
 module ReleaseNotes
-  VERSION = "0.0.1"
+  VERSION = "0.0.2"
 end

--- a/spec/lib/release_notes/changelog_parser_spec.rb
+++ b/spec/lib/release_notes/changelog_parser_spec.rb
@@ -10,79 +10,87 @@ describe ReleaseNotes::ChangelogParser do
     let(:issue_one) { "#3" }
     let(:pr_one) { create_merged_pr(change_one, issue_one) }
     let(:default_result) { "#### Closed PRS:" + create_result(pr_one, change_one, issue_one) }
-    let(:default_changelog) { ["Closed PR: ##{pr_one[:number]} - #{pr_one[:title]} Closes:  #{issue_one} "] }
+    let(:default_changelog) { "Closed PR: ##{pr_one[:number]} - #{pr_one[:title]} Closes:  #{issue_one} " }
     let(:nothing_added) { "No Closed PRS" }
 
-    describe 'special_handling' do
-      it 'does not include merged_prs that have not checked Include this PR in changelog with bullet' do
-        pr_one[:text].gsub!('### Special Handling - [x] Include this PR in the changelog', '### Special Handling - [] Include this PR in the changelog')
-        expect(subject.assemble_changelog([pr_one])).to eq(nothing_added)
+    describe 'prepare_changelog_body' do
+      let(:new_sha) { 'new_sha' }
+      let(:old_sha) { 'old_sha' }
+
+      context 'special handling' do
+        it 'does not include merged_prs that have not checked Include this PR in changelog with bullet' do
+          pr_one[:text].gsub!('### Special Handling - [x] Include this PR in the changelog', '### Special Handling - [] Include this PR in the changelog')
+          expect(subject.prepare_changelog_body(new_sha, old_sha, 'server_name', [pr_one])).to include(nothing_added)
+        end
+
+        it 'does not update the changelog if no merged_prs are passed' do
+          prs = []
+          expect(subject.prepare_changelog_body(new_sha, old_sha, 'server_name', prs)).to include(nothing_added)
+        end
+
+        it 'includes merged_prs that are checked to Include this PR in changelog with bullet' do
+          expect(subject.prepare_changelog_body(new_sha, old_sha, 'server_name', [pr_one])).to include(default_result)
+        end
+
+        it 'includes merged_prs that have not checked Include this PR in changelog without bullet' do
+          pr_one[:text].gsub!('### Special Handling - [x] Include this PR in the changelog', '### Special Handling [x] Include this PR in the changelog')
+          expect(subject.prepare_changelog_body(new_sha, old_sha, 'server_name', [pr_one])).to include(default_result)
+        end
       end
 
-      it 'does not update the changelog if no merged_prs are passed' do
-        prs = []
-        expect(subject.assemble_changelog(prs)).to eq(nothing_added)
+      it 'informs that it is the First Deploy if nothing to compare against' do
+        old_sha = nil
+        expect(subject.prepare_changelog_body(new_sha, old_sha, 'server_name', [pr_one])).to include("First Deploy")
       end
 
-      it 'includes merged_prs that are checked to Include this PR in changelog with bullet' do
-        expect(subject.assemble_changelog([pr_one])).to eq(default_result)
-      end
-
-      it 'includes merged_prs that have not checked Include this PR in changelog without bullet' do
-        pr_one[:text].gsub!('### Special Handling - [x] Include this PR in the changelog', '### Special Handling [x] Include this PR in the changelog')
-        expect(subject.assemble_changelog([pr_one])).to eq(default_result)
-      end
-    end
-
-    describe "#changelog_summary" do
-      it 'does not include merged_prs that have not checked Include this PR in changelog with bullet' do
-        pr_one[:text].gsub!('### Special Handling - [x] Include this PR in the changelog', '### Special Handling - [] Include this PR in the changelog')
-        expect(subject.changelog_summary([pr_one])).to eq([nothing_added])
-      end
-
-      it 'does not update the changelog if no merged_prs are passed' do
-        prs = []
-        expect(subject.changelog_summary(prs)).to eq([nothing_added])
-      end
-
-      it 'includes merged_prs that are checked to Include this PR in changelog with bullet' do
-        expect(subject.changelog_summary([pr_one])).to eq(default_changelog)
-      end
-
-      it 'includes merged_prs that have not checked Include this PR in changelog without bullet' do
-        pr_one[:text].gsub!('### Special Handling - [x] Include this PR in the changelog', '### Special Handling [x] Include this PR in the changelog')
-        expect(subject.changelog_summary([pr_one])).to eq(default_changelog)
-      end
-    end
-
-    describe 'parsing' do
       it 'parses when given notes from multiple prs' do
         change_two = "- adds map"
         issue_two = "#20"
         pr_two = create_merged_pr(change_two, issue_two)
-        expect(subject.assemble_changelog([pr_one, pr_two])).to eq("#### Closed PRS:" + create_result(pr_one, change_one, issue_one) + create_result(pr_two, change_two, issue_two))
+        expect(subject.prepare_changelog_body(new_sha, old_sha, 'server_name', [pr_one, pr_two])).to include("#### Closed PRS:" + create_result(pr_one, change_one, issue_one) + create_result(pr_two, change_two, issue_two))
       end
 
       it 'parses content with # in them' do
         change_two = "- adds map using `#some_method`"
         issue_two = "#20"
         pr_two = create_merged_pr(change_two, issue_two)
-        expect(subject.assemble_changelog([pr_one, pr_two])).to include("#{change_two}")
+        expect(subject.prepare_changelog_body(new_sha, old_sha, 'server_name', [pr_one, pr_two])).to include("#{change_two}")
       end
 
       it 'returns content to inform nothing was closed when issue data is missing' do
         pr = pr_one.merge(text: "### Changes #{change_one} ### Special Handling - [x] Include this PR in the changelog")
-        expect(subject.assemble_changelog([pr])).to include("Nothing Closed")
+        expect(subject.prepare_changelog_body(new_sha, old_sha, 'server_name', [pr])).to include("Nothing Closed")
       end
 
       it 'returns content to inform nothing was changed when template data is missing' do
         pr = pr_one.merge(text: "### Closes #{issue_one} ### Special Handling - [x] Include this PR in the changelog")
-        expect(subject.assemble_changelog([pr])).to include("No Changes included in the log")
+        expect(subject.prepare_changelog_body(new_sha, old_sha, 'server_name', [pr])).to include("No Changes included in the log")
       end
 
       it 'returns content correctly when change_notes have ##' do
         pr = pr_one.merge(text: "## Changes #{change_one} ### Closes #{issue_one} ### Special Handling - [x] Include this PR in the changelog")
-        expect(subject.assemble_changelog([pr])).to eq(default_result)
+        expect(subject.prepare_changelog_body(new_sha, old_sha, 'server_name', [pr])).to include(default_result)
+      end
+    end
+
+    describe "#prepare_changelog_summary" do
+      it 'does not include merged_prs that have not checked Include this PR in changelog with bullet' do
+        pr_one[:text].gsub!('### Special Handling - [x] Include this PR in the changelog', '### Special Handling - [] Include this PR in the changelog')
+        expect(subject.prepare_changelog_summary('server_name', [pr_one])).to include(nothing_added)
+      end
+
+      it 'does not update the changelog if no merged_prs are passed' do
+        prs = []
+        expect(subject.prepare_changelog_summary('server_name', prs)).to include(nothing_added)
+      end
+
+      it 'includes merged_prs that are checked to Include this PR in changelog with bullet' do
+        expect(subject.prepare_changelog_summary('server_name', [pr_one])).to include(default_changelog)
+      end
+
+      it 'includes merged_prs that have not checked Include this PR in changelog without bullet' do
+        pr_one[:text].gsub!('### Special Handling - [x] Include this PR in the changelog', '### Special Handling [x] Include this PR in the changelog')
+        expect(subject.prepare_changelog_summary('server_name', [pr_one])).to include(default_changelog)
       end
     end
   end

--- a/spec/lib/release_notes/manager_spec.rb
+++ b/spec/lib/release_notes/manager_spec.rb
@@ -27,10 +27,6 @@ describe ReleaseNotes::Manager do
 
     subject { ReleaseNotes::Manager.new(@repo, @access_token, DEFAULT_SERVER) }
 
-    it 'informs that it is the First Deploy if nothing to compare against' do
-      expect(ReleaseNotes::Manager.new(@repo, @access_token, "fake").changelog_body(nil, [pr])).to include("First Deploy")
-    end
-
     context 'when commits are merged into one branch and then merged into another_branch' do
       let(:branch_one) { create_branch }
       let(:branch_two) { create_branch }

--- a/spec/lib/release_notes/manager_spec.rb
+++ b/spec/lib/release_notes/manager_spec.rb
@@ -9,10 +9,25 @@ describe ReleaseNotes::Manager do
 
   before(:all) do
     @access_token = ENV['GITHUB_API_TOKEN']
-    @test_client = Octokit::Client.new(access_token: @access_token)
+    @test_client = Octokit::Client.new(access_token: @access_token, site_admin: true)
     @test_client.login
-    @repo = @test_client.create_repo('test_release_notes', description: "testing gitHubAPI", auto_init: true).full_name
+    @repository = @test_client.create_repo('test_release_notes', description: "testing gitHubAPI", auto_init: true)
+    @repo = @repository.full_name
     @api = ReleaseNotes::GithubAPI.new(@repo, ENV['GITHUB_API_TOKEN'])
+  end
+
+  describe '#push_changelog_to_github' do
+    let(:changelog) { { summary: "Summary of changes", body: "Any Text"} }
+    subject { ReleaseNotes::Manager.new(@repo, @access_token, 'Test Name') }
+
+    it 'creates a changelog on the repo' do
+      expect { subject.push_changelog_to_github(changelog) }.to change { @test_client.commits(@repo).count }.by(1)
+    end
+
+    it 'creates a changelog on repos passed in' do
+      another_repo = @test_client.create_repo('another_repo', description: "testing gitHubAPI", auto_init: true).full_name
+      expect { subject.push_changelog_to_github(changelog, another_repo) }.to change { @test_client.commits(another_repo).count }.by(1)
+    end
   end
 
   describe '#texts_from_merged_pr' do


### PR DESCRIPTION
- a repo may have a number of clients, and we want to set the changelog to a specific client rather than the parent repo.
- allow a `changelog_repo` to be passed in, this is the repo where a changelog will be created.
- this still creates a changelog at the base repo, so that the parent repo can see all the changelogs. 