### PR TITLE
Set changelog repo path

### DIFF
--- a/lib/release_notes/changelog_file.rb
+++ b/lib/release_notes/changelog_file.rb
@@ -16,12 +16,16 @@ module ReleaseNotes
         body: ChangelogParser.prepare_changelog_body(new_sha, old_sha, server_name, prs) }
     end
 
-    def push_to_github(repo, changelog)
+    def prepend_to_existing(changelog)
+      return changelog[:body] unless github_file.present?
+      changelog[:body] + old_changelog_content
+    end
+
+    def push_to_github(repo, summary, body)
       if github_file.present?
-        changelog_body = changelog[:body] + old_changelog_content
-        @api.update_changelog(repo, github_file, changelog[:summary], changelog_body)
+        @api.update_changelog(repo, github_file, summary, body)
       else
-        @api.create_content(repo, @file_path, changelog[:body])
+        @api.create_content(repo, @file_path, body)
       end
     end
 

--- a/lib/release_notes/manager.rb
+++ b/lib/release_notes/manager.rb
@@ -31,8 +31,9 @@ module ReleaseNotes
 
     def push_changelog_to_github(content, *repos)
       repos = Array(@repo) if repos.empty?
+      changelog_body = @changelog.prepend_to_existing(content)
       repos.flatten.compact.each do |repo|
-        @changelog.push_to_github(repo, content)
+        @changelog.push_to_github(repo, content[:summary], changelog_body)
       end
     end
 


### PR DESCRIPTION
Fixes Duplicate text in changelog when there are multiple repos passed in. 

Fixes https://github.com/clouie87/release_notes/issues/32