### PR TITLE
Improve the way we determine merged PRs

### DIFF
--- a/lib/release_notes/github_api.rb
+++ b/lib/release_notes/github_api.rb
@@ -13,8 +13,23 @@ module ReleaseNotes
       @client.auto_paginate = true
     end
 
-    def find_commits_between(commit_old_sha, commit_new_sha)
+    def get_commits_between(commit_old_sha, commit_new_sha)
       @client.compare(@repo, commit_old_sha, commit_new_sha).commits
+    end
+
+    def get_merged_pull_requests(commits)
+      commit_messages = commits.pluck(:commit).pluck(:message)
+      pull_request_ids = get_pull_request_ids(commit_messages)
+
+      pull_request_ids.map do |id|
+        @client.pull_request(@repo, id, state: 'closed')
+      end
+    end
+
+    def get_pull_request_ids(commit_messages)
+      commit_messages.map do |message|
+        Regexp.last_match(1) if message.match(/Merge pull request #(\d*).*/)
+      end.compact
     end
 
     def find_tag_by_name(tag_name)
@@ -28,28 +43,6 @@ module ReleaseNotes
 
     def find_tag(tag_sha)
       @client.tag(@repo, tag_sha)
-    end
-
-    def merged_pull_requests(old_sha)
-      closed_pull_requests_between(old_sha).select(&:merged_at?)
-    end
-
-    def closed_pull_requests_between(old_sha)
-      closed_pull_requests.take_while do |pr|
-        pr.updated_at > last_commit_date(old_sha)
-      end
-    end
-
-    def last_commit_date(old_sha)
-      @client.commit(@repo, old_sha).commit.committer.date
-    end
-
-    def closed_pull_requests
-      @client.pull_requests(@repo, state: 'closed', sort: 'updated', direction: "desc")
-    end
-
-    def find_pull_request_commits(pr)
-      @client.pull_request_commits(@repo, pr)
     end
 
     def branch(branch)

--- a/lib/release_notes/manager.rb
+++ b/lib/release_notes/manager.rb
@@ -24,9 +24,9 @@ module ReleaseNotes
 
     def create_changelog_from_sha(new_sha, old_sha: nil)
       old_sha ||= last_commit_sha
-      prs = texts_from_merged_pr(new_sha, old_sha) if old_sha
+      prs = merged_pull_requests(new_sha, old_sha) if old_sha
 
-      @changelog.prepare(new_sha, old_sha, prs)
+      @changelog.prepare(new_sha, old_sha, pull_requests_attributes(prs))
     end
 
     def push_changelog_to_github(content, *repos)
@@ -37,9 +37,10 @@ module ReleaseNotes
       end
     end
 
-    def texts_from_merged_pr(new_sha, old_sha)
-      commits_between_tags = @api.find_commits_between(old_sha, new_sha)
-      matching_pr_commits(commits_between_tags, old_sha).map { |commit| {number: commit.number, title: commit.title, text: commit.body.squish } }
+    def merged_pull_requests(new_sha, old_sha)
+      commits_between_tags = @api.get_commits_between(old_sha, new_sha)
+
+      @api.get_merged_pull_requests(commits_between_tags)
     end
 
     private
@@ -52,10 +53,9 @@ module ReleaseNotes
       ChangelogParser.last_commit(server_name, @changelog.metadata)
     end
 
-    # find the prs that contain the commits between two tags
-    def matching_pr_commits(commits, old_sha)
-      @api.merged_pull_requests(old_sha).select do |pr|
-        (@api.find_pull_request_commits(pr.number).map(&:sha) - commits.map(&:sha)).empty?
+    def pull_requests_attributes(prs)
+      prs.map do |pr|
+        { number: pr.number, title: pr.title, text: pr.body.squish }
       end
     end
   end


### PR DESCRIPTION
Previously we were getting all of our merged pull requests (more than 6000), and then filtering by a date. This is very time consuming. Instead determine which pull requests were closed between the two commit shas and then only look up a limited number of PRs (a significantly less number than all).