### PR TITLE
Fix issues with branch names

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -11,4 +11,4 @@ gemspec
 # your gem to rubygems.org.
 
 # To use a debugger
-# gem 'byebug', group: [:development, :test]
+gem 'byebug', group: [:development, :test]

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,26 +1,37 @@
 PATH
   remote: .
   specs:
-    release_notes (0.0.1)
+    release_notes (0.0.2)
+      activesupport
+      octokit (~> 4.0)
 
 GEM
   remote: https://rubygems.org/
   specs:
-    activesupport (5.0.0.1)
+    activesupport (6.1.1)
       concurrent-ruby (~> 1.0, >= 1.0.2)
-      i18n (~> 0.7)
-      minitest (~> 5.1)
-      tzinfo (~> 1.1)
-    addressable (2.4.0)
-    concurrent-ruby (1.0.2)
+      i18n (>= 1.6, < 2)
+      minitest (>= 5.1)
+      tzinfo (~> 2.0)
+      zeitwerk (~> 2.3)
+    addressable (2.7.0)
+      public_suffix (>= 2.0.2, < 5.0)
+    byebug (11.1.3)
+    concurrent-ruby (1.1.8)
     diff-lcs (1.2.5)
-    faraday (0.9.2)
+    faraday (1.3.0)
+      faraday-net_http (~> 1.0)
       multipart-post (>= 1.2, < 3)
-    i18n (0.7.0)
-    minitest (5.9.1)
-    multipart-post (2.0.0)
-    octokit (4.4.1)
-      sawyer (~> 0.7.0, >= 0.5.3)
+      ruby2_keywords
+    faraday-net_http (1.0.1)
+    i18n (1.8.10)
+      concurrent-ruby (~> 1.0)
+    minitest (5.14.4)
+    multipart-post (2.1.1)
+    octokit (4.20.0)
+      faraday (>= 0.9)
+      sawyer (~> 0.8.0, >= 0.5.3)
+    public_suffix (4.0.6)
     rspec (3.5.0)
       rspec-core (~> 3.5.0)
       rspec-expectations (~> 3.5.0)
@@ -34,21 +45,21 @@ GEM
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.5.0)
     rspec-support (3.5.0)
-    sawyer (0.7.0)
-      addressable (>= 2.3.5, < 2.5)
-      faraday (~> 0.8, < 0.10)
-    thread_safe (0.3.5)
-    tzinfo (1.2.2)
-      thread_safe (~> 0.1)
+    ruby2_keywords (0.0.4)
+    sawyer (0.8.2)
+      addressable (>= 2.3.5)
+      faraday (> 0.8, < 2.0)
+    tzinfo (2.0.4)
+      concurrent-ruby (~> 1.0)
+    zeitwerk (2.4.2)
 
 PLATFORMS
   ruby
 
 DEPENDENCIES
-  activesupport
-  octokit (~> 4.0)
+  byebug
   release_notes!
   rspec (~> 3.0)
 
 BUNDLED WITH
-   1.11.2
+   1.17.3

--- a/lib/release_notes/github_api.rb
+++ b/lib/release_notes/github_api.rb
@@ -63,12 +63,12 @@ module ReleaseNotes
       return nil
     end
 
-    def update_changelog(repo, file, summary, changelog_content, branch: "master")
-      @client.update_contents(repo, file.path, summary, file.sha, changelog_content, branch: "master")
+    def update_changelog(repo, file, summary, changelog_content)
+      @client.update_contents(repo, file.path, summary, file.sha, changelog_content)
     end
 
-    def create_content(repo, file, changelog_content, message: "Creating Changelog", branch: "master")
-      @client.create_content(repo, file, message, changelog_content, branch: branch)
+    def create_content(repo, file, changelog_content, message: "Creating Changelog")
+      @client.create_content(repo, file, message, changelog_content)
     end
   end
 end

--- a/spec/lib/release_notes/manager_spec.rb
+++ b/spec/lib/release_notes/manager_spec.rb
@@ -47,7 +47,7 @@ describe ReleaseNotes::Manager do
 
   describe '#texts_from_merged_pr' do
     let(:branch) { create_branch }
-    let(:pr) { setup_issue_commit_pr('master', branch) }
+    let(:pr) { setup_issue_commit_pr('main', branch) }
 
     before(:each) do
       sleep 1 # Github Best Practices https://developer.github.com/guides/best-practices-for-integrators/#dealing-with-rate-limits
@@ -73,7 +73,7 @@ describe ReleaseNotes::Manager do
 
       it 'finds all the pr texts when a branch is merged into another branch' do
         subject.create_changelog_from_sha(pr.merge_commit_sha)
-        pr_five =  create_and_merge_pull_request(main_branch: 'master', feature_branch: branch_one)
+        pr_five =  create_and_merge_pull_request(main_branch: 'main', feature_branch: branch_one)
         expect(subject.texts_from_merged_pr(pr_five.merge_commit_sha, pr.merge_commit_sha)).to include(pr_commit(pr_five), pr_commit(pr_four), pr_commit(pr_three))
       end
 
@@ -132,7 +132,7 @@ def create_commit(commit_name, branch_name)
   add_content(commit_name, branch_name: branch_name)
 end
 
-def create_and_merge_pull_request(main_branch: 'master', feature_branch: nil, body: 'dummyText', issue: nil)
+def create_and_merge_pull_request(main_branch: 'main', feature_branch: nil, body: 'dummyText', issue: nil)
   pr = @test_client.create_pull_request(@repo, main_branch, feature_branch, body, pull_request_body(issue))
   merge_pull_request(pr.number)
   @test_client.pull_request(@repo, pr.number)
@@ -142,11 +142,11 @@ def merge_pull_request(number)
   @test_client.merge_pull_request(@repo, number)
 end
 
-def tagging_commit(branch: 'master')
+def tagging_commit(branch: 'main')
   @test_client.branch(@repo, branch).commit.sha
 end
 
-def add_content(tag, branch_name: "master")
+def add_content(tag, branch_name: "main")
   @test_client.create_content(@repo, "lib/test#{tag}.rb", 'AddingContent', 'Closes Issue#1', :branch => branch_name)
 end
 


### PR DESCRIPTION
If I do not pass a branch name in, it will use the default branch. This is better than the way I was explicitly setting it to master. This means it will work for both our base branch "main" and our clients branches "master" 

Bump up gems