### PR TITLE
Change log enhancements

### DIFF
--- a/lib/release_notes/changelog_parser.rb
+++ b/lib/release_notes/changelog_parser.rb
@@ -42,7 +42,7 @@ module ReleaseNotes
 
     def self.changelog_prs(prs)
       return [] unless prs
-      prs.select { |pr| pr if pr[:text].include?(INCLUDE_PR_TEXT) }
+      prs.select { |pr| pr[:text]&.include?(INCLUDE_PR_TEXT) }
     end
 
     def self.changelog_prs_text(prs)

--- a/lib/release_notes/manager.rb
+++ b/lib/release_notes/manager.rb
@@ -55,6 +55,7 @@ module ReleaseNotes
     # find the prs that contain the commits between two tags
     def matching_pr_commits(commits, old_sha)
       @api.merged_pull_requests(old_sha).select do |pr|
+        print '.'
         (@api.find_pull_request_commits(pr.number).map(&:sha) - commits.map(&:sha)).empty?
       end
     end

--- a/lib/release_notes/version.rb
+++ b/lib/release_notes/version.rb
@@ -1,3 +1,3 @@
 module ReleaseNotes
-  VERSION = "0.0.2"
+  VERSION = "0.0.3"
 end


### PR DESCRIPTION
Rather than getting all the PRs for the repo, and then selecting the ones that are earlier than the last commit_date, check the PRs each time I get a list. This way we do not need to get thousands of PRs, if we only need the first 30 or so.

Related to: https://github.com/combinaut/sparkle-scripps/issues/1724