### PR TITLE
fix: Incomplete list of commits being returned

### DIFF
--- a/lib/release_notes/github_api.rb
+++ b/lib/release_notes/github_api.rb
@@ -13,7 +13,18 @@ module ReleaseNotes
     end
 
     def find_commits_between(commit_old_sha, commit_new_sha)
-      @client.compare(@repo, commit_old_sha, commit_new_sha).commits
+      found_commits = []
+      1.step do |page|
+        current_commits = @client.compare(@repo, commit_old_sha, commit_new_sha, page: page).commits
+        puts "Associated commits for page: #{page}"
+
+        break if current_commits.count.zero?
+
+        found_commits += current_commits
+        sleep(1)
+      end
+
+      return found_commits
     end
 
     def find_tag_by_name(tag_name)

--- a/lib/release_notes/version.rb
+++ b/lib/release_notes/version.rb
@@ -1,3 +1,3 @@
 module ReleaseNotes
-  VERSION = "0.0.3"
+  VERSION = "0.0.4"
 end


### PR DESCRIPTION
I found that only 250 commits were being returned, when there should have been thousands. Make sure to paginate through the commits.