### PR TITLE
Update dependencies for rails-6

### DIFF
--- a/release_notes.gemspec
+++ b/release_notes.gemspec
@@ -19,5 +19,5 @@ Gem::Specification.new do |s|
 
   s.add_dependency "activesupport"
   s.add_development_dependency "rspec", "~> 3.0"
-  s.add_dependency "octokit", "~> 4.0"
+  s.add_dependency "octokit", "~> 5.0"
 end

--- a/release_notes.gemspec
+++ b/release_notes.gemspec
@@ -19,5 +19,5 @@ Gem::Specification.new do |s|
 
   s.add_dependency "activesupport"
   s.add_development_dependency "rspec", "~> 3.0"
-  s.add_dependency "octokit", "~> 6.0"
+  s.add_dependency "octokit", "~> 10"
 end

--- a/release_notes.gemspec
+++ b/release_notes.gemspec
@@ -19,5 +19,5 @@ Gem::Specification.new do |s|
 
   s.add_dependency "activesupport"
   s.add_development_dependency "rspec", "~> 3.0"
-  s.add_dependency "octokit", "~> 5.0"
+  s.add_dependency "octokit", "~> 6.0"
 end


### PR DESCRIPTION
Current version of Octokit seems to be cause this error with the rails-6-upgrade branch of Sparkle

```
	11: from /Users/darrenwalker/Combinaut/sparkle/.bundle/ruby/2.7.0/gems/octokit-4.25.1/lib/octokit/default.rb:17:in `<top (required)>'
	10: from /Users/darrenwalker/Combinaut/sparkle/.bundle/ruby/2.7.0/gems/octokit-4.25.1/lib/octokit/default.rb:19:in `<module:Octokit>'
	 9: from /Users/darrenwalker/Combinaut/sparkle/.bundle/ruby/2.7.0/gems/octokit-4.25.1/lib/octokit/default.rb:33:in `<module:Default>'
	 8: from /Users/darrenwalker/Combinaut/sparkle/.bundle/ruby/2.7.0/gems/octokit-4.25.1/lib/octokit/default.rb:33:in `new'
	 7: from /Users/darrenwalker/Combinaut/sparkle/.bundle/ruby/2.7.0/gems/faraday-1.9.0/lib/faraday/rack_builder.rb:65:in `initialize'
	 6: from /Users/darrenwalker/Combinaut/sparkle/.bundle/ruby/2.7.0/gems/faraday-1.9.0/lib/faraday/rack_builder.rb:76:in `build'
	 5: from /Users/darrenwalker/Combinaut/sparkle/.bundle/ruby/2.7.0/gems/octokit-4.25.1/lib/octokit/default.rb:37:in `block in <module:Default>'
	 4: from /Users/darrenwalker/Combinaut/sparkle/.bundle/ruby/2.7.0/gems/activesupport-6.0.6.1/lib/active_support/dependencies.rb:324:in `require'
	 3: from /Users/darrenwalker/Combinaut/sparkle/.bundle/ruby/2.7.0/gems/activesupport-6.0.6.1/lib/active_support/dependencies.rb:291:in `load_dependency'
	 2: from /Users/darrenwalker/Combinaut/sparkle/.bundle/ruby/2.7.0/gems/activesupport-6.0.6.1/lib/active_support/dependencies.rb:324:in `block in require'
	 1: from /Users/darrenwalker/Combinaut/sparkle/.bundle/ruby/2.7.0/gems/zeitwerk-2.6.18/lib/zeitwerk/kernel.rb:34:in `require'
/Users/darrenwalker/Combinaut/sparkle/.bundle/ruby/2.7.0/gems/zeitwerk-2.6.18/lib/zeitwerk/kernel.rb:34:in `require': cannot load such file -- /Users/darrenwalker/Combinaut/sparkle/.bundle/ruby/2.7.0/gems/faraday-1.9.0/lib/faraday/request/retry (LoadError)
```